### PR TITLE
adds in fixes for ie style quirks refs #25

### DIFF
--- a/phmi/static/css/styles.css
+++ b/phmi/static/css/styles.css
@@ -438,6 +438,9 @@ form #org_list .search {
 form #org_list .search:focus {
   outline: 0;
 }
+form #org_list .search::-ms-clear {
+  display: none;
+}
 form #org_list ul {
   border: 1px solid #d8dde0;
   border-top: 0;

--- a/phmi/static/css/styles.scss
+++ b/phmi/static/css/styles.scss
@@ -526,6 +526,12 @@ form {
       &:focus {
         outline: 0;
       }
+
+      &::-ms-clear {
+        display: none;
+      }
+
+
     }
 
     ul {

--- a/phmi/templates/group_form.html
+++ b/phmi/templates/group_form.html
@@ -89,7 +89,7 @@
                 <div id="org_list">
                   <div class="relative">
                     <div class="search-icon"><i class="fa fa-search"></i></div>
-                    <input class="search" placeholder="Search Organisations" />
+                    <input class="search form-control" placeholder="Search Organisations" />
                   </div>
                   <ul class="list list-unstyled">
                     {% for org_type, orgs in orgs_by_type %}


### PR DESCRIPTION
Fixes the search box height and fixes the x that appears when you add text to the search box.

It doesn't remove the small cursor jump on focus. I don't think this is a noticeable issue and the solution is not obvious (ie has lots of issues around input placeholder and focus)
